### PR TITLE
cljsjs! also upgrades cljs, om and core.async

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,11 +11,11 @@
                  [enlive "1.1.5"]
                  [com.cognitect/transit-clj "0.8.255"]
 
-                 [org.clojure/clojurescript "0.0-2322"]
-                 [org.clojure/core.async "0.1.338.0-5c5012-alpha"]
+                 [org.clojure/clojurescript "0.0-2740"]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [com.cognitect/transit-cljs "0.8.188"]
-                 [om "0.7.3"]
-                 [secretary "1.1.0"]
+                 [org.omcljs/om "0.8.7" :as om]
+                 [cljsjs/d3 "3.5.3-0"]
                  [com.cemerick/url "0.1.1"]]
   :plugins      [[lein-cljsbuild "1.0.3"]
                  [datomic-schema-grapher "0.0.1"]
@@ -32,15 +32,11 @@
         :source-map "resources/public/javascript/build/client-dev.js.map"
         :optimizations :whitespace
         :pretty-print true
-        :preamble ["react/react.js"
-                   "vendor/scroll_into_view_polyfill.js"
-                   "vendor/d3.v3.js"
+        :preamble ["vendor/scroll_into_view_polyfill.js"
                    "vendor/topojson.js"
                    "vendor/colorbrewer.js"
                    "vendor/enquire.js"]
-        :externs ["react/externs/react.js"
-                  "externs/d3_externs_min.js"
-                  "externs/topojson.js"
+        :externs ["externs/topojson.js"
                   "externs/colorbrewer.js"
                   "externs/ga.js"
                   "externs/enquire.js"]}}
@@ -52,15 +48,11 @@
         :source-map "resources/public/javascript/advanced/client.js.map"
         :optimizations :advanced
         :pretty-print false
-        :preamble ["react/react.min.js"
-                   "vendor/scroll_into_view_polyfill.js"
-                   "vendor/d3.v3.js"
+        :preamble ["vendor/scroll_into_view_polyfill.js"
                    "vendor/topojson.js"
                    "vendor/colorbrewer.js"
                    "vendor/enquire.js"]
-        :externs ["react/externs/react.js"
-                  "externs/d3_externs_min.js"
-                  "externs/topojson.js"
+        :externs ["externs/topojson.js"
                   "externs/colorbrewer.js"
                   "externs/ga.js"
                   "externs/enquire.js"]}}
@@ -70,15 +62,11 @@
        {:output-to "resources/public/javascript/client.js"
         :optimizations :advanced
         :pretty-print false
-        :preamble ["react/react.min.js"
-                   "vendor/scroll_into_view_polyfill.js"
-                   "vendor/d3.v3.js"
+        :preamble ["vendor/scroll_into_view_polyfill.js"
                    "vendor/topojson.js"
                    "vendor/colorbrewer.js"
                    "vendor/enquire.js"]
-        :externs ["react/externs/react.js"
-                  "externs/d3_externs_min.js"
-                  "externs/topojson.js"
+        :externs ["externs/topojson.js"
                   "externs/colorbrewer.js"
                   "externs/ga.js"
                   "externs/enquire.js"]}}}}

--- a/src/cljs/bird_wave/client.cljs
+++ b/src/cljs/bird_wave/client.cljs
@@ -7,6 +7,7 @@
             [om.dom :as dom :include-macros true]
             [goog.events :as events]
             [cljs.core.async :as async :refer (chan put! <! timeout)]
+            [cljsjs.d3]
             [bird-wave.map :refer (init-axis color active-state zoom zoom-duration
                                   svg-dim state-to-activate active-attrs target
                                   prevent-zoom-on-drag init-map update-map make-frequencies)]

--- a/src/cljs/bird_wave/map.cljs
+++ b/src/cljs/bird_wave/map.cljs
@@ -1,6 +1,7 @@
 (ns bird-wave.map
   (:require [clojure.string :as cs]
-            [bird-wave.util :refer (analytic-event)]))
+            [bird-wave.util :refer (analytic-event)]
+            [cljsjs.d3]))
 
 (def svg-dim {:width 768 :height 500})
 (def key-dim {:width 10 :height 200})

--- a/src/cljs/bird_wave/util.cljs
+++ b/src/cljs/bird_wave/util.cljs
@@ -1,5 +1,6 @@
 (ns bird-wave.util
-  (:require [cognitect.transit :as transit]))
+  (:require [cognitect.transit :as transit]
+            [cljsjs.d3]))
 
 (defn log [& args]
   (if js/window.__birdwave_debug__


### PR DESCRIPTION
Removes react and d3 from cljsbuild config, adds cljsjs and requires.

Note: for d3, the cljs code still says js/d3 because the library itself is still loaded globally.
